### PR TITLE
fix default grpc-gateway connect timeout

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -38,6 +38,7 @@ func MustNewServer(c GatewayConf, opts ...Option) *Server {
 	svr := &Server{
 		Server:    rest.MustNewServer(c.RestConf),
 		upstreams: c.Upstreams,
+		timeout:   time.Duration(c.Timeout) * time.Millisecond,
 	}
 	for _, opt := range opts {
 		opt(svr)


### PR DESCRIPTION
Fix the problem that the default grpc-gateway connects to the rpc server timeout

bug issue: #3140